### PR TITLE
Intelligently skip Opening Balance line

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Date,Counter Party,Reference,Type,Amount (GBP),Balance (GBP)
 03/04/2018,Company B,BILL 54312,CHAPS,-500.20,750.30
 ```
 
+> **Note:** Sometimes the _Opening Balance_ line is not included in the CSV. This tool automatically skips the _Opening Balance_ line if it is included in the input CSV.
+
 Then run 
 
 ```

--- a/s2f.py
+++ b/s2f.py
@@ -9,8 +9,10 @@ def convertCSV(filename):
         rdr = csv.reader(source)
         wtr = csv.writer(result, delimiter=',', )
         next(rdr)  # Skip CSV headers
-        next(rdr)  # Skip "Opening balance."
         for row in rdr:
+            # Skip opening balance if it is present
+            if (row[0] == "" and row[1] == "Opening Balance"):
+                continue
             wtr.writerow([row[0], row[4], row[2]])
 
 def main(argv):


### PR DESCRIPTION
Lots of my Starling CSV exports don't include the _Opening Balance_ line at the beginning, so instead a transaction gets unnecessarily removed.

However, I didn't want to remove that line entirely as I'm not sure if some Starling CSV exports do still include that line.

Therefore this change only skips the _Opening Balance_ line if one is detected.

Thanks for considering my PR :) 